### PR TITLE
fix(pdf-export): preserve table borders across split pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 ## [Unreleased]
 
 ### Fixed
+- Improve research PDF table continuity at page breaks by adding fragment-safe cell edge rendering (`td` inset shadow) so split rows keep a visible bottom line.
 - Standardize metric formatting across all tables with shared `metric-formatter` module — consistent currency auto-promotion ($M→$B), percent, ratio, and bps formatting.
 - Fix double-counted source citations in executive summary bullets across all rendering pipelines.
 - Fix KPI table scale mismatch where column header shows ($M) but values show $22.3B — new `tableMode` suppresses scale suffixes in table cells.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ### Fixed
 - Improve research PDF table continuity at page breaks by adding fragment-safe cell edge rendering (`td` inset shadow) so split rows keep a visible bottom line.
+- Fix promotional articles leaking through LLM filter by adding `excludedIds` array to LLM output schema and cross-referencing it programmatically; raise batch `max_tokens` from 8K to 12K, bringing batch success rate from 35% to 100%.
 - Standardize metric formatting across all tables with shared `metric-formatter` module — consistent currency auto-promotion ($M→$B), percent, ratio, and bps formatting.
 - Fix double-counted source citations in executive summary bullets across all rendering pipelines.
 - Fix KPI table scale mismatch where column header shows ($M) but values show $22.3B — new `tableMode` suppresses scale suffixes in table cells.

--- a/backend/src/api/research/export-pdf.ts
+++ b/backend/src/api/research/export-pdf.ts
@@ -55,6 +55,7 @@ const footerTextHtml = `
 
 const pdfFooterTemplate = footerWaveDataUri
   ? `<div style="position:relative;width:100%;height:100%;overflow:hidden;-webkit-print-color-adjust:exact;margin-bottom:-20px;">
+       <div style="position:absolute;top:0;left:-32px;width:calc(100% + 64px);height:18px;background:#ffffff;z-index:3;-webkit-print-color-adjust:exact;"></div>
        <img src="${footerWaveDataUri}" style="position:absolute;bottom:0;left:-32px;width:calc(100% + 64px);height:auto;z-index:0;" />
        ${footerTextHtml}
      </div>`
@@ -83,7 +84,9 @@ const htmlTemplate = (params: { title: string; meta: string[]; body: string }) =
     .section { margin-bottom: 18px; }
     table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 11px; }
     th, td { border: 1px solid #e5e7eb; padding: 6px; text-align: left; vertical-align: top; }
+    td { box-shadow: inset 0 -2px 0 #e5e7eb; }
     th { background: ${BRAND_BLUE}; color: #ffffff; font-weight: 600; -webkit-print-color-adjust: exact; }
+    thead { display: table-header-group; }
     code { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 11px; }
     ul { padding-left: 18px; }
     ol { padding-left: 20px; }
@@ -195,7 +198,7 @@ export async function exportResearchPdf(req: Request, res: Response) {
         format: 'Letter' as const,
         displayHeaderFooter: true,
         footerTemplate: pdfFooterTemplate,
-        margin: { top: '80px', bottom: '0.75in', left: '32px', right: '32px' },
+        margin: { top: '80px', bottom: '0.95in', left: '32px', right: '32px' },
         printBackground: true,
         timeout: 30000,
       };

--- a/backend/src/api/research/export-pdf.ts
+++ b/backend/src/api/research/export-pdf.ts
@@ -23,6 +23,7 @@ const assetsDir = fs.existsSync(path.resolve(__dirname, '../../../assets'))
 const BRAND_BLUE = '#003399';
 const BRAND_DK2 = '#336179';
 const BODY_COLOR = '#111827';
+const BORDER_GRAY = '#e5e7eb';
 const FONT_STACK = '"Avenir Next LT Pro", "Helvetica Neue", Arial, sans-serif';
 
 // ── Load assets as base64 data URIs (once at module init) ─────────────
@@ -83,8 +84,8 @@ const htmlTemplate = (params: { title: string; meta: string[]; body: string }) =
     .meta { color: #4b5563; font-size: 11px; line-height: 1.4; margin: 0 0 4px 0; }
     .section { margin-bottom: 18px; }
     table { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 11px; }
-    th, td { border: 1px solid #e5e7eb; padding: 6px; text-align: left; vertical-align: top; }
-    td { box-shadow: inset 0 -2px 0 #e5e7eb; }
+    th, td { border: 1px solid ${BORDER_GRAY}; padding: 6px; text-align: left; vertical-align: top; }
+    td { box-shadow: inset 0 -2px 0 ${BORDER_GRAY}; }
     th { background: ${BRAND_BLUE}; color: #ffffff; font-weight: 600; -webkit-print-color-adjust: exact; }
     thead { display: table-header-group; }
     code { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 11px; }


### PR DESCRIPTION
## Summary
- Improve research PDF table rendering at page boundaries so split table cells retain a visible bottom edge.

## Changes
- Add `td { box-shadow: inset 0 -2px 0 #e5e7eb; }` in research PDF export stylesheet to render a fragment-safe bottom edge on split cells.
- Keep repeated table headers for multi-page tables with `thead { display: table-header-group; }`.
- Align research PDF bottom margin to `0.95in` and keep footer masking strip behavior in the footer template.
- Update `CHANGELOG.md` under `[Unreleased]`.

## Testing
- [x] Not run (explain why)
- [ ] Unit tests
- [ ] Integration tests
- [ ] E2E tests
- [ ] Manual (describe below)

Details:
- Did not run full backend validation in this branch because repository-wide pre-existing typecheck issues are currently failing in unrelated news/admin modules.

## Changelog
- [x] Updated `CHANGELOG.md` under `[Unreleased]`
- [ ] If not user-facing, added: "No user-facing changes."

## Screenshots / Video (if UI)
- N/A (PDF styling change)

## Risk / Rollback
- Risk: Low to medium. `td` shadow may slightly thicken visual row separators in dense tables.
- Rollback plan: Revert commit `fdded6b`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved research PDF table continuity across page breaks for consistent bottom lines and clearer row separation.
  * Standardized table border styling, added subtle cell dividers, enhanced footer spacing when wave backgrounds are used, and increased PDF bottom margin for better layout.

* **Chores**
  * Reduced unwanted promotional content in LLM outputs by adding exclusion handling and increased batch processing capacity for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->