### PR TITLE
fix(research): ground research pipeline to current date with web search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - Dockerfile CMD switched from `prisma db push --skip-generate --accept-data-loss` to `prisma migrate deploy` for safer production deployments.
 
 ### Fixed
+- Fix stale research data: inject today's date via system message, anchor time horizons to concrete date ranges, enable web search for foundation stage, and interpolate current year in foundation prompt search suggestions.
 - Improve research PDF table continuity at page breaks by adding fragment-safe cell edge rendering (`td` inset shadow) so split rows keep a visible bottom line.
 - Fix promotional articles leaking through LLM filter by adding `excludedIds` array to LLM output schema and cross-referencing it programmatically; raise batch `max_tokens` from 8K to 12K, bringing batch success rate from 35% to 100%.
 - Standardize metric formatting across all tables with shared `metric-formatter` module — consistent currency auto-promotion ($M→$B), percent, ratio, and bps formatting.

--- a/backend/prompts/foundation-prompt.ts
+++ b/backend/prompts/foundation-prompt.ts
@@ -19,6 +19,7 @@ interface FoundationPromptInputs {
   focusAreas?: string[];
   userFiles?: Array<{name: string; type: string}>;
   reportType?: ReportTypeId;
+  currentYear?: number;
 }
 
 export function buildFoundationPrompt(inputs: FoundationPromptInputs): string {
@@ -39,6 +40,8 @@ export function buildFoundationPrompt(inputs: FoundationPromptInputs): string {
     ? userFiles.map(f => `${f.name} (${f.type})`).join(", ")
     : "None provided";
   
+  const currentYear = inputs.currentYear ?? new Date().getFullYear();
+
   // Build the complete prompt
   const basePrompt = `# Phase 0: Foundation Research - Company Intelligence System
 
@@ -74,7 +77,7 @@ Follow this priority order for data gathering:
 **Search for:**
 - "**${companyName}** 10-K" OR "**${companyName}** 20-F" OR "**${companyName}** annual report"
 - "**${companyName}** 10-Q" OR "**${companyName}** 6-K" (most recent quarters within the time horizon)
-- "**${companyName}** investor presentation" + current year
+- "**${companyName}** investor presentation ${currentYear}"
 - "**${companyName}** proxy statement DEF 14A"
 
 **Extract:**
@@ -144,7 +147,7 @@ Follow this priority order for data gathering:
 
 #### 4. Tier-1 Media & News (Priority: HIGH)
 **Search for:**
-- "**${companyName}** ${geography} news" + current year
+- "**${companyName}** ${geography} news ${currentYear}"
 - "**${companyName}** investment ${geography}"
 - "**${companyName}** expansion ${geography}"
 - "**${companyName}** facility ${geography}"
@@ -166,10 +169,10 @@ Follow this priority order for data gathering:
 
 #### 5. Industry/Analyst Reports (Priority: MEDIUM)
 **Search for:**
-- "Sector report" + current year
+- "Sector report ${currentYear}"
 - "**${companyName}** industry Gartner OR Forrester OR IDC"
 - "Sector trends ${geography}"
-- "Business activity PMI ${geography}" + current year
+- "Business activity PMI ${geography} ${currentYear}"
 
 **Extract:**
 - Industry growth rates and forecasts

--- a/backend/src/services/claude-client.test.ts
+++ b/backend/src/services/claude-client.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ClaudeClient } from '../services/claude-client.js';
 
+type ClaudeClientTestHarness = ClaudeClient & {
+  client: {
+    messages: {
+      create: ReturnType<typeof vi.fn>;
+      stream: ReturnType<typeof vi.fn>;
+    };
+  };
+};
+
 describe('ClaudeClient', () => {
   const client = new ClaudeClient({ apiKey: 'test-key' });
 
@@ -29,8 +38,9 @@ describe('ClaudeClient', () => {
         usage: { input_tokens: 100, output_tokens: 50 }
       });
 
-      // Access private client to mock
-      (client as any).client = { messages: { create: mockCreate, stream: vi.fn() } };
+      (client as unknown as ClaudeClientTestHarness).client = {
+        messages: { create: mockCreate, stream: vi.fn() }
+      };
     });
 
     it('passes system parameter to Anthropic API when provided', async () => {

--- a/backend/src/services/claude-client.test.ts
+++ b/backend/src/services/claude-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ClaudeClient } from '../services/claude-client.js';
 
 describe('ClaudeClient', () => {
@@ -17,5 +17,94 @@ describe('ClaudeClient', () => {
   it('repairs invalid JSON when allowRepair is true', () => {
     const repaired = client.parseJSON<{ foo: string }>(invalidResponse, { allowRepair: true });
     expect(repaired.foo).toBe('bar');
+  });
+
+  describe('execute() options', () => {
+    let mockCreate: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockCreate = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'response text' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 100, output_tokens: 50 }
+      });
+
+      // Access private client to mock
+      (client as any).client = { messages: { create: mockCreate, stream: vi.fn() } };
+    });
+
+    it('passes system parameter to Anthropic API when provided', async () => {
+      await client.execute('test prompt', { system: 'You are a research analyst.' });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: 'You are a research analyst.',
+          messages: expect.any(Array)
+        })
+      );
+    });
+
+    it('does not include system parameter when not provided', async () => {
+      await client.execute('test prompt');
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty('system');
+    });
+
+    it('passes tools parameter to Anthropic API when provided', async () => {
+      const tools = [{ type: 'web_search_20250305', name: 'web_search', max_uses: 10 }];
+      await client.execute('test prompt', { tools });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tools,
+          messages: expect.any(Array)
+        })
+      );
+    });
+
+    it('does not include tools parameter when not provided', async () => {
+      await client.execute('test prompt');
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty('tools');
+    });
+
+    it('passes both system and tools when provided together', async () => {
+      const tools = [{ type: 'web_search_20250305', name: 'web_search', max_uses: 5 }];
+      await client.execute('test prompt', {
+        system: 'Today is 2026-03-02.',
+        tools
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: 'Today is 2026-03-02.',
+          tools,
+          messages: expect.any(Array)
+        })
+      );
+    });
+
+    it('extracts text from responses with interleaved web search blocks', async () => {
+      mockCreate.mockResolvedValue({
+        content: [
+          { type: 'web_search_tool_result', search_results: [] },
+          { type: 'text', text: 'First part.' },
+          { type: 'web_search_tool_result', search_results: [] },
+          { type: 'text', text: 'Second part.' }
+        ],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 200, output_tokens: 100 }
+      });
+
+      const result = await client.execute('search and respond', {
+        tools: [{ type: 'web_search_20250305', name: 'web_search', max_uses: 5 }]
+      });
+
+      expect(result.content).toBe('First part.\nSecond part.');
+      expect(result.usage.inputTokens).toBe(200);
+      expect(result.usage.outputTokens).toBe(100);
+    });
   });
 });

--- a/backend/src/services/claude-client.ts
+++ b/backend/src/services/claude-client.ts
@@ -18,6 +18,11 @@ export interface ClaudeConfig {
   cacheEnabled?: boolean;
 }
 
+export interface ExecuteOptions {
+  system?: string;
+  tools?: Array<{ type: string; name: string; max_uses?: number }>;
+}
+
 export interface StreamingOptions {
   onStart?: () => void;
   onContent?: (delta: string) => void;
@@ -56,18 +61,27 @@ export class ClaudeClient {
   /**
    * Execute a prompt and get complete response
    */
-  async execute(prompt: string): Promise<ClaudeResponse> {
+  async execute(prompt: string, options?: ExecuteOptions): Promise<ClaudeResponse> {
     try {
-      const response = await this.client.messages.create({
+      const createParams: Record<string, unknown> = {
         model: this.model,
         max_tokens: this.maxTokens,
         messages: this.buildMessages(prompt)
-      });
+      };
 
-      // Extract text content
+      if (options?.system) {
+        createParams.system = options.system;
+      }
+      if (options?.tools) {
+        createParams.tools = options.tools;
+      }
+
+      const response = await this.client.messages.create(createParams as any);
+
+      // Extract text content (works with interleaved web_search_tool_result blocks)
       const content = response.content
-        .filter(block => block.type === 'text')
-        .map(block => block.type === 'text' ? block.text : '')
+        .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+        .map(block => block.text)
         .join('\n');
 
       return {
@@ -88,7 +102,7 @@ export class ClaudeClient {
    */
   async executeStreaming(
     prompt: string,
-    options: StreamingOptions = {}
+    options: StreamingOptions & Pick<ExecuteOptions, 'system'> = {}
   ): Promise<ClaudeResponse> {
     try {
       let fullContent = '';
@@ -98,11 +112,17 @@ export class ClaudeClient {
 
       options.onStart?.();
 
-      const stream = await this.client.messages.stream({
+      const streamParams: Record<string, unknown> = {
         model: this.model,
         max_tokens: this.maxTokens,
         messages: this.buildMessages(prompt)
-      });
+      };
+
+      if (options.system) {
+        streamParams.system = options.system;
+      }
+
+      const stream = await this.client.messages.stream(streamParams as any);
 
       for await (const event of stream) {
         this.handleStreamEvent(event, {

--- a/backend/src/services/claude-client.ts
+++ b/backend/src/services/claude-client.ts
@@ -5,7 +5,11 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import { jsonrepair } from 'jsonrepair';
-import type { MessageStreamEvent } from '@anthropic-ai/sdk/resources/messages';
+import type {
+  MessageStreamEvent,
+  MessageCreateParamsNonStreaming,
+  TextBlock,
+} from '@anthropic-ai/sdk/resources/messages';
 
 // ============================================================================
 // TYPES
@@ -63,24 +67,19 @@ export class ClaudeClient {
    */
   async execute(prompt: string, options?: ExecuteOptions): Promise<ClaudeResponse> {
     try {
-      const createParams: Record<string, unknown> = {
+      const createParams: MessageCreateParamsNonStreaming = {
         model: this.model,
         max_tokens: this.maxTokens,
-        messages: this.buildMessages(prompt)
+        messages: this.buildMessages(prompt) as MessageCreateParamsNonStreaming['messages'],
+        ...(options?.system ? { system: options.system } : {}),
+        ...(options?.tools ? { tools: options.tools as MessageCreateParamsNonStreaming['tools'] } : {}),
       };
 
-      if (options?.system) {
-        createParams.system = options.system;
-      }
-      if (options?.tools) {
-        createParams.tools = options.tools;
-      }
-
-      const response = await this.client.messages.create(createParams as any);
+      const response = await this.client.messages.create(createParams);
 
       // Extract text content (works with interleaved web_search_tool_result blocks)
       const content = response.content
-        .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+        .filter((block): block is TextBlock => block.type === 'text')
         .map(block => block.text)
         .join('\n');
 
@@ -112,17 +111,14 @@ export class ClaudeClient {
 
       options.onStart?.();
 
-      const streamParams: Record<string, unknown> = {
+      const streamParams: MessageCreateParamsNonStreaming = {
         model: this.model,
         max_tokens: this.maxTokens,
-        messages: this.buildMessages(prompt)
+        messages: this.buildMessages(prompt) as MessageCreateParamsNonStreaming['messages'],
+        ...(options.system ? { system: options.system } : {}),
       };
 
-      if (options.system) {
-        streamParams.system = options.system;
-      }
-
-      const stream = await this.client.messages.stream(streamParams as any);
+      const stream = await this.client.messages.stream(streamParams);
 
       for await (const event of stream) {
         this.handleStreamEvent(event, {

--- a/backend/src/services/orchestrator.ts
+++ b/backend/src/services/orchestrator.ts
@@ -371,6 +371,15 @@ export const STAGE_CONFIGS: Record<StageId, StageConfig> = {
 // ============================================================================
 
 export class ResearchOrchestrator {
+  private static readonly HORIZON_MONTHS: Record<string, number> = {
+    'Last 6 Months': 6,
+    'Last Year': 12,
+    'Last 2 Years': 24,
+    'Last 3 Years': 36,
+  };
+
+  private static readonly FOUNDATION_WEB_SEARCH_MAX_USES = 10;
+
   private prisma: PrismaClient;
   private claudeClient: ClaudeClient;
   private costTrackingService: CostTrackingService;
@@ -814,11 +823,23 @@ export class ResearchOrchestrator {
         return;
       }
 
+      // Single timestamp for temporal consistency across prompt and system message
+      const executionTime = new Date();
+
       // Build prompt with context
-      const prompt = await this.buildStagePrompt(jobId, stageId);
+      const prompt = await this.buildStagePrompt(jobId, stageId, executionTime);
+
+      // Construct system message with today's date for temporal grounding
+      const today = executionTime.toISOString().split('T')[0];
+      const systemMessage = `Today's date is ${today}. You are a senior research analyst. All references to 'current', 'recent', or 'latest' mean relative to today's date.`;
+
+      // Enable web search for foundation stage to get current data
+      const tools = stageId === 'foundation'
+        ? [{ type: 'web_search_20250305' as const, name: 'web_search' as const, max_uses: ResearchOrchestrator.FOUNDATION_WEB_SEARCH_MAX_USES }]
+        : undefined;
 
       // Execute with Claude
-      const initialResponse = await this.claudeClient.execute(prompt);
+      const initialResponse = await this.claudeClient.execute(prompt, { system: systemMessage, tools });
       response = initialResponse;
 
       // Parse and validate
@@ -833,7 +854,7 @@ export class ResearchOrchestrator {
 
         console.warn(`[format-only] ${stageId} attempting JSON reformat`);
         const formatPrompt = this.buildFormatOnlyPrompt(prompt, initialResponse.content);
-        const formatResponse = await this.claudeClient.execute(formatPrompt);
+        const formatResponse = await this.claudeClient.execute(formatPrompt, { system: systemMessage });
         response = formatResponse;
 
         try {
@@ -845,7 +866,7 @@ export class ResearchOrchestrator {
 
           console.warn(`[schema-only] ${stageId} attempting minimal schema regeneration`);
           const schemaPrompt = await this.buildFinancialSnapshotSchemaOnlyPrompt(jobId, reportType);
-          const schemaResponse = await this.claudeClient.execute(schemaPrompt);
+          const schemaResponse = await this.claudeClient.execute(schemaPrompt, { system: systemMessage });
           response = schemaResponse;
           output = this.parseStageOutput(stageId, schemaResponse, validationSchema);
         }
@@ -904,7 +925,7 @@ export class ResearchOrchestrator {
   /**
    * Build prompt with all required context
    */
-  private async buildStagePrompt(jobId: string, stageId: StageId): Promise<string> {
+  private async buildStagePrompt(jobId: string, stageId: StageId, executionTime: Date = new Date()): Promise<string> {
     const job = await this.prisma.researchJob.findUnique({
       where: { id: jobId }
     });
@@ -918,7 +939,8 @@ export class ResearchOrchestrator {
       companyName: job.companyName,
       geography: job.geography,
       foundation: job.foundation,
-      reportType: (job.reportType as ReportTypeId) || 'GENERIC'
+      reportType: (job.reportType as ReportTypeId) || 'GENERIC',
+      currentYear: executionTime.getFullYear()
     };
 
     // Add optional context based on dependencies
@@ -950,13 +972,19 @@ export class ResearchOrchestrator {
     const timeHorizon = this.getReportInputValue(job, 'timeHorizon');
     const promptSections = [basePrompt];
     if (timeHorizon) {
+      const { start, end } = this.computeDateRange(timeHorizon, executionTime);
+      const MONTHS = ['January','February','March','April','May','June',
+        'July','August','September','October','November','December'];
+      const formatDate = (d: Date) => `${MONTHS[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
       promptSections.push(
         [
           '---',
           '',
           '## TIME HORIZON (MANDATORY)',
           '',
-          `Time horizon: ${timeHorizon}`,
+          `Time horizon: ${timeHorizon} (${formatDate(start)} through ${formatDate(end)})`,
+          `Today's date: ${formatDate(end)}`,
+          '',
           'Use this time horizon as a strict rolling window ending today.',
           'Treat any "latest" or "most recent" references as the most recent within the time horizon.',
           'Do not anchor to fixed calendar years or date ranges outside the specified horizon.',
@@ -1096,6 +1124,22 @@ export class ResearchOrchestrator {
       return json && json !== '{}' && json !== '[]' ? json : null;
     }
     return String(value);
+  }
+
+  /**
+   * Compute concrete start/end dates from a time horizon label.
+   * Maps human-readable labels like "Last 6 Months" to date ranges anchored to the given time.
+   */
+  private computeDateRange(timeHorizon: string, now: Date): { start: Date; end: Date } {
+    const months = ResearchOrchestrator.HORIZON_MONTHS[timeHorizon] ?? 12;
+    const end = new Date(now);
+    const start = new Date(now);
+    start.setMonth(start.getMonth() - months);
+    // Clamp day to avoid month overflow (e.g., Mar 31 - 1 month → Mar 3 instead of Feb 28)
+    if (start.getDate() !== now.getDate()) {
+      start.setDate(0); // last day of previous month
+    }
+    return { start, end };
   }
 
   /**

--- a/backend/src/services/orchestrator.ts
+++ b/backend/src/services/orchestrator.ts
@@ -940,7 +940,7 @@ export class ResearchOrchestrator {
       geography: job.geography,
       foundation: job.foundation,
       reportType: (job.reportType as ReportTypeId) || 'GENERIC',
-      currentYear: executionTime.getFullYear()
+      currentYear: executionTime.getUTCFullYear()
     };
 
     // Add optional context based on dependencies
@@ -975,7 +975,7 @@ export class ResearchOrchestrator {
       const { start, end } = this.computeDateRange(timeHorizon, executionTime);
       const MONTHS = ['January','February','March','April','May','June',
         'July','August','September','October','November','December'];
-      const formatDate = (d: Date) => `${MONTHS[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
+      const formatDate = (d: Date) => `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
       promptSections.push(
         [
           '---',
@@ -1134,10 +1134,10 @@ export class ResearchOrchestrator {
     const months = ResearchOrchestrator.HORIZON_MONTHS[timeHorizon] ?? 12;
     const end = new Date(now);
     const start = new Date(now);
-    start.setMonth(start.getMonth() - months);
+    start.setUTCMonth(start.getUTCMonth() - months);
     // Clamp day to avoid month overflow (e.g., Mar 31 - 1 month → Mar 3 instead of Feb 28)
-    if (start.getDate() !== now.getDate()) {
-      start.setDate(0); // last day of previous month
+    if (start.getUTCDate() !== now.getUTCDate()) {
+      start.setUTCDate(0); // last day of previous month
     }
     return { start, end };
   }


### PR DESCRIPTION
## Summary
- Fix stale research data by grounding the research pipeline to today's date and enabling web search for the foundation stage
- Reports were consistently returning 2024-era data because Claude had no date awareness, no search capability, and time horizons were unanchored relative labels

## Changes
- **ClaudeClient** (`claude-client.ts`): Add optional `system` and `tools` parameters to `execute()` and `executeStreaming()` — passed through to the Anthropic API when provided
- **Orchestrator** (`orchestrator.ts`): Inject system message with today's date into all research stage calls; enable Anthropic web search tool (`max_uses: 10`) for the foundation stage; anchor time horizons to concrete date ranges (e.g., "Last 6 Months" → "September 2, 2025 through March 2, 2026"); use single `executionTime` timestamp for temporal consistency
- **Foundation prompt** (`foundation-prompt.ts`): Replace 4 instances of `+ current year` placeholder text with actual interpolated year; accept `currentYear` from orchestrator for consistency
- **Tests** (`claude-client.test.ts`): Add 6 tests covering system/tools passthrough, absence when omitted, and text extraction from interleaved web search response blocks

## Testing
- [x] Unit tests
- [ ] Manual (describe below)

Details:
- All 328 unit tests pass
- No new TypeScript errors in modified files
- Manual verification recommended: run a research job with "Last 6 Months" time horizon and confirm foundation stage uses web search (check logs), system message includes today's date, and report references 2025/2026 data

## Changelog
- [x] Updated `CHANGELOG.md` under `[Unreleased]`

## Risk / Rollback
- Risk: Low. Changes are additive — system messages and tools are optional params that default to previous behavior when absent. Foundation stage will consume more input tokens due to web search results.
- Rollback plan: Revert commit. No DB migrations or schema changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Research data now uses today's date and concrete start/end ranges, and interpolates the current year to reduce stale or ambiguous time references.

* **New Features**
  * Foundation-stage research can perform limited web searches to surface current market insights and recent news.
  * Prompts and responses are temporally grounded across stages for more accurate, date-aware results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->