### PR TITLE
fix(ci): switch deploy to OIDC auth and correct app name

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -9,7 +9,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  AZURE_WEBAPP_NAME: ssa-intelligence
+  AZURE_WEBAPP_NAME: ssami
 
 jobs:
   build-and-push:
@@ -59,17 +59,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     environment: production
+    permissions:
+      id-token: write
     env:
-      AZURE_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+      HAS_AZURE_CREDS: ${{ secrets.AZURE_CLIENT_ID != '' }}
     steps:
+      - name: Azure Login (OIDC)
+        if: env.HAS_AZURE_CREDS == 'true'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Deploy to Azure Web App
-        if: env.AZURE_PUBLISH_PROFILE != ''
+        if: env.HAS_AZURE_CREDS == 'true'
         uses: azure/webapps-deploy@v3
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}
-          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha }}
 
-      - name: Skip deploy (no Azure secret configured)
-        if: env.AZURE_PUBLISH_PROFILE == ''
-        run: echo "AZURE_WEBAPP_PUBLISH_PROFILE secret not set — skipping Azure deployment."
+      - name: Skip deploy (no Azure credentials configured)
+        if: env.HAS_AZURE_CREDS != 'true'
+        run: echo "Azure OIDC credentials not set — skipping deployment."


### PR DESCRIPTION
## Summary
- Replace publish-profile auth with Azure OIDC (federated credentials) — basic auth is disabled on the App Service
- Update Azure Web App name from `ssa-intelligence` to `ssami`

## Changes
- Deploy job now uses `azure/login@v2` with OIDC instead of `publish-profile`
- Requires three GitHub secrets: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
- Removes dependency on `AZURE_WEBAPP_PUBLISH_PROFILE` secret
- Gracefully skips deploy if Azure credentials aren't configured

## Testing
- [x] Manual (describe below)

Details:
- Verified service principal and federated credential created in Azure
- GitHub secrets added to repository
- Pipeline will be tested end-to-end on merge to main

## Changelog
- [x] No user-facing changes.

## Risk / Rollback
- Risk: Low — only changes the deploy job auth method
- Rollback plan: Revert to publish-profile if OIDC doesn't work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment authentication method from publish profile-based to Azure AD/OIDC-based approach.
  * Updated Azure Web App configuration and naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->