### PR TITLE
fix(api): strip port from proxy IP for Azure rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - Update Azure deploy target from `ssami` to `SSAMI1` (East US region) for VNet compatibility.
 
 ### Fixed
+- Fix rate limiter crash on Azure: strip port suffix from proxy-forwarded IP addresses so `express-rate-limit` receives valid IPs.
 - Fix stale research data: inject today's date via system message, anchor time horizons to concrete date ranges, enable web search for foundation stage, and interpolate current year in foundation prompt search suggestions.
 - Improve research PDF table continuity at page breaks by adding fragment-safe cell edge rendering (`td` inset shadow) so split rows keep a visible bottom line.
 - Fix promotional articles leaking through LLM filter by adding `excludedIds` array to LLM output schema and cross-referencing it programmatically; raise batch `max_tokens` from 8K to 12K, bringing batch success rate from 35% to 100%.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -69,7 +69,7 @@ const __dirname = path.dirname(__filename);
 // MIDDLEWARE
 // ============================================================================
 
-// Trust Render/hosted proxy so req.ip reflects the client IP (required for rate limiting)
+// Trust Azure/hosted proxy so req.ip reflects the client IP (required for rate limiting)
 app.set('trust proxy', 1);
 
 // CORS
@@ -94,11 +94,17 @@ const parseEnvInt = (name: string, fallback: number) => {
 };
 const isProd = !['development', 'test'].includes(process.env.NODE_ENV ?? '');
 
+// Azure proxy may pass IP with port (e.g. "1.2.3.4:9396"); strip the port
+// so express-rate-limit gets a valid IP address.
+const stripPort = (ip: string) => ip.replace(/:\d+$/, '');
+const keyGenerator = (req: express.Request) => stripPort(req.ip ?? '127.0.0.1');
+
 const getLimiter: RequestHandler | undefined = isProd
   ? rateLimit({
       windowMs: parseEnvInt('RATE_LIMIT_GET_WINDOW_MS', 300000), // 5 minutes
       max: parseEnvInt('RATE_LIMIT_GET_MAX', 2000),
-      message: rateLimitMessage
+      message: rateLimitMessage,
+      keyGenerator
     })
   : undefined;
 
@@ -106,7 +112,8 @@ const generateLimiter: RequestHandler | undefined = isProd
   ? rateLimit({
       windowMs: parseEnvInt('RATE_LIMIT_GENERATE_WINDOW_MS', 900000), // 15 minutes
       max: parseEnvInt('RATE_LIMIT_GENERATE_MAX', 10),
-      message: rateLimitMessage
+      message: rateLimitMessage,
+      keyGenerator
     })
   : undefined;
 
@@ -114,7 +121,8 @@ const exportLimiter: RequestHandler | undefined = isProd
   ? rateLimit({
       windowMs: parseEnvInt('RATE_LIMIT_EXPORT_WINDOW_MS', 3600000), // 60 minutes
       max: parseEnvInt('RATE_LIMIT_EXPORT_MAX', 20),
-      message: rateLimitMessage
+      message: rateLimitMessage,
+      keyGenerator
     })
   : undefined;
 
@@ -122,7 +130,8 @@ const writeLimiter: RequestHandler | undefined = isProd
   ? rateLimit({
       windowMs: parseEnvInt('RATE_LIMIT_WRITE_WINDOW_MS', 900000), // 15 minutes
       max: parseEnvInt('RATE_LIMIT_WRITE_MAX', 60),
-      message: rateLimitMessage
+      message: rateLimitMessage,
+      keyGenerator
     })
   : undefined;
 
@@ -131,7 +140,8 @@ const feedbackLimiter: RequestHandler | undefined = isProd
   ? rateLimit({
       windowMs: 15 * 60 * 1000,
       max: 5,
-      message: rateLimitMessage
+      message: rateLimitMessage,
+      keyGenerator
     })
   : undefined;
 


### PR DESCRIPTION
## Summary
- Fix `ERR_ERL_INVALID_IP_ADDRESS` crash on Azure: Azure's proxy forwards client IPs with a port suffix (e.g. `1.2.3.4:9396`) which `express-rate-limit` rejects.

## Changes
- Add custom `keyGenerator` to all rate limiters that strips the port suffix from `req.ip`
- Update trust proxy comment from Render to Azure
- Update CHANGELOG.md

## Testing
- [x] Manual (describe below)

Details:
- `npx tsc --noEmit` passes cleanly
- Verified the `ValidationError: An invalid 'request.ip'` error in Azure Log stream; this fix addresses it

## Changelog
- [x] Updated `CHANGELOG.md` under `[Unreleased]`

## Risk / Rollback
- Risk: Low — only affects how rate limiter reads client IP, no behavioral change
- Rollback plan: Revert the keyGenerator additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a runtime crash in rate limiting on Azure-hosted environments by properly validating client IP addresses. Rate limiting now operates reliably in production without service disruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->