### PR TITLE
fix(render): escape pipe characters in markdown table cells

### DIFF
--- a/backend/src/services/rendering-helpers.ts
+++ b/backend/src/services/rendering-helpers.ts
@@ -10,7 +10,8 @@ export const normalizeCell = (cell: string | number | null | undefined): string 
   if (cell === null || cell === undefined) return '';
   const s = String(cell).trim();
   if (s === '–' || s === '-' || s === '—' || /^n\/?a$/i.test(s)) return '';
-  return s;
+  // Escape pipe characters so they don't break markdown table columns
+  return s.replace(/\|/g, '\\|');
 };
 
 /** Treat dashes, N/A, and similar placeholders as empty (no real data). */

--- a/frontend/src/utils/rendering-helpers.ts
+++ b/frontend/src/utils/rendering-helpers.ts
@@ -10,7 +10,8 @@ export const normalizeCell = (cell: string | number | null | undefined): string 
   if (cell === null || cell === undefined) return '';
   const s = String(cell).trim();
   if (s === '–' || s === '-' || s === '—' || /^n\/?a$/i.test(s)) return '';
-  return s;
+  // Escape pipe characters so they don't break markdown table columns
+  return s.replace(/\|/g, '\\|');
 };
 
 /** Treat dashes, N/A, and similar placeholders as empty (no real data). */


### PR DESCRIPTION
## Summary
- Fix markdown table rendering when citation text contains pipe characters (e.g., `Revenue 2012–2025 | COKE`)

## Changes
- **backend/src/services/rendering-helpers.ts**: Escape `|` to `\|` in `normalizeCell`
- **frontend/src/utils/rendering-helpers.ts**: Same fix (kept in sync per file comment)

## Testing
- [x] Unit tests

Details:
- All 328 tests pass
- Discovered on Render's Coca-Cola Consolidated report where S18 citation `MacroTrends: 'Coca-Cola Consolidated Revenue 2012–2025 | COKE'` had its pipe interpreted as a column delimiter, shifting data into wrong columns and dropping the URL

## Changelog
- [ ] If not user-facing, added: "No user-facing changes."

## Screenshots / Video (if UI)
- N/A

## Risk / Rollback
- Risk: Very low — only affects markdown table cell escaping
- Rollback plan: Revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)